### PR TITLE
BAU-28231 Fixed the Snyk vulnerabilities with 800+ score

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -269,8 +269,16 @@ class Run extends Command
 
     protected function matchTestFromFilename($filename, $tests_path)
     {
+        // Basic validation: ensure filename is a string and not too long
+        if (!is_string($filename) || strlen($filename) > 1024) {
+            throw new \InvalidArgumentException("Invalid test filename");
+        }
+
+        // Escape regex special characters in $tests_path
+        $safe_tests_path = preg_quote($tests_path, '~');
         $filename = str_replace(array('//', '\/', '\\'), '/', $filename);
-        $res      = preg_match("~^$tests_path/(.*?)/(.*)$~", $filename, $matches);
+
+        $res = preg_match("~^{$safe_tests_path}/(.*?)/(.*)$~", $filename, $matches);
         if (! $res) {
             throw new \InvalidArgumentException("Test file can't be matched");
         }

--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -178,6 +178,10 @@ class SelfUpdate extends Command
                 $phar = new \Phar($temp);
                 // free the variable to unlock the file
                 unset($phar);
+                // Add this validation before rename($temp, $this->filename);
+                if (!is_string($this->filename) || !preg_match('/^[\w\-\.\/]+\.phar$/', $this->filename) || strpos($this->filename, '..') !== false) {
+                    throw new \Exception('Invalid filename for update.');
+                }
                 rename($temp, $this->filename);
             } else {
                 throw new \Exception('Request failed.');

--- a/src/Codeception/Configuration.php
+++ b/src/Codeception/Configuration.php
@@ -178,7 +178,14 @@ class Configuration
 
     protected static function autoloadHelpers()
     {
-        Autoload::registerSuffix('Helper', self::helpersDir());
+        $helpersDir = self::helpersDir();
+
+        // Sanitize helpersDir to allow only safe characters (alphanumeric, underscore, dash, slash, dot)
+        if (!is_string($helpersDir) || !preg_match('/^[\w\-\/\.]+$/', $helpersDir)) {
+            throw new \InvalidArgumentException('Invalid helpers directory path');
+        }
+
+        Autoload::registerSuffix('Helper', $helpersDir);
     }
 
     protected static function loadSuites()


### PR DESCRIPTION
This PR addresses Snyk-identified vulnerabilities in the Codeception project with a severity score of 800+. The fixes focus on improving input validation and sanitization to prevent potential security issues related to unsafe file and directory handling.

## Changes
**1. `src/Codeception/Command/Run.php`**
- Added validation to ensure the test filename is a string and not excessively long.
- Escaped regex special characters in the `$tests_path` to prevent regex injection vulnerabilities during test file matching.

**2. `src/Codeception/Command/SelfUpdate.php`**
- Introduced a validation step to sanitize the filename used for updates. Ensures the filename is a string, matches a safe pattern for `.phar` files, and does not contain directory traversal (`..`).

**3. `src/Codeception/Configuration.php`**
- Sanitized the helpers directory path before registering autoload suffixes. Only allows alphanumeric, underscore, dash, slash, and dot characters to prevent unsafe directory paths.
