### PR TITLE
BAU-28233 Fixed the Path Traversal issue from SelfUpdate.php file

### DIFF
--- a/src/Codeception/Command/SelfUpdate.php
+++ b/src/Codeception/Command/SelfUpdate.php
@@ -178,7 +178,13 @@ class SelfUpdate extends Command
                 $phar = new \Phar($temp);
                 // free the variable to unlock the file
                 unset($phar);
-                rename($temp, $this->filename);
+                // Before using $this->filename in rename
+                $realFilename = realpath($this->filename);
+                if ($realFilename === false || strpos($realFilename, getcwd()) !== 0) {
+                    throw new \Exception('Invalid target filename for update.');
+                }
+                rename($temp, $realFilename);
+                $this->filename = $realFilename;
             } else {
                 throw new \Exception('Request failed.');
             }


### PR DESCRIPTION
This pull request addresses a security vulnerability in the `SelfUpdate.php` file related to path traversal. The vulnerability could have allowed an attacker to overwrite files outside the intended directory by manipulating the target filename during the self-update process.

### Changes Made
- Introduced validation using `realpath($this->filename)` to resolve the absolute path of the target file.
- Ensured the resolved path is within the application's current working directory by checking it starts with `getcwd()`.
- If the target filename is invalid or points outside the allowed directory, an exception is thrown and the update does not proceed.
- The PHAR file is only renamed and updated if all security checks pass.

### Motivation
This change is necessary to prevent potential path traversal attacks during the self-update process, ensuring that updates cannot overwrite files outside the application directory.
