### PR TITLE
Bau 28341 codeception vulnerabilities 400 part 2

### DIFF
--- a/tests/data/app/controllers.php
+++ b/tests/data/app/controllers.php
@@ -93,9 +93,9 @@ class cookies {
     }
 
     function POST() {
-        setcookie('f', 'b', time() + 60, null, null, false, true);
-        setcookie('foo', 'bar1', time() + 60, null, 'sub.localhost', false, true);
-        setcookie('baz', 'bar2', time() + 60,  null, 'sub.localhost', false, true);
+        setcookie('f', 'b', time() + 60, null, null, true, true);
+        setcookie('foo', 'bar1', time() + 60, null, 'sub.localhost', true, true);
+        setcookie('baz', 'bar2', time() + 60,  null, 'sub.localhost', true, true);
         data::set('form', $_POST);
         include __DIR__.'/view/cookies.php';
     }

--- a/tests/data/claypit/c3.php
+++ b/tests/data/claypit/c3.php
@@ -37,7 +37,7 @@ if (!function_exists('__c3_error')) {
         if (!headers_sent()) {
             header('X-Codeception-CodeCoverage-Error: ' . str_replace("\n", ' ', $message), true, 500);
         }
-        setcookie('CODECEPTION_CODECOVERAGE_ERROR', $message);
+        setcookie('CODECEPTION_CODECOVERAGE_ERROR', $message, 0, '', '', true, true);
     }
 }
 

--- a/tests/unit/Codeception/Module/SoapTest.php
+++ b/tests/unit/Codeception/Module/SoapTest.php
@@ -17,6 +17,16 @@ class SoapTest extends \PHPUnit_Framework_TestCase
 
     protected $layout;
 
+    private function createSecureDomDocument() {
+        if (LIBXML_VERSION < 20900 && function_exists('libxml_disable_entity_loader')) {
+            libxml_disable_entity_loader(true);
+        }
+        $dom = $this->createSecureDomDocument();
+        $dom->resolveExternals = false;
+        $dom->substituteEntities = false;
+        return $dom;
+    }
+
     public function setUp() {
         $this->module = new \Codeception\Module\SOAP();
         $this->module->_setConfig(['schema' => 'http://www.w3.org/2001/xml.xsd', 'endpoint' => 'http://codeception.com/api/wsdl']);
@@ -27,7 +37,7 @@ class SoapTest extends \PHPUnit_Framework_TestCase
     }
     
     public function testXmlIsBuilt() {
-        $dom = new \DOMDocument();
+        $dom = $this->createSecureDomDocument();
         $dom->load($this->layout);
         $this->assertEqualXMLStructure($this->module->xmlRequest->documentElement, $dom->documentElement);
         $this->assertXmlStringEqualsXmlString($dom->saveXML(), $this->module->xmlRequest->saveXML());
@@ -35,7 +45,7 @@ class SoapTest extends \PHPUnit_Framework_TestCase
     
     public function testBuildHeaders() {
         $this->module->haveSoapHeader('AuthHeader', ['username' => 'davert', 'password' => '123456']);
-        $dom = new \DOMDocument();
+        $dom = $this->createSecureDomDocument();
         $dom->load($this->layout);
         $header = $dom->createElement('AuthHeader');
         $header->appendChild($dom->createElement('username','davert'));
@@ -48,7 +58,7 @@ class SoapTest extends \PHPUnit_Framework_TestCase
     {
         $this->module->sendSoapRequest('KillHumans', "<item><id>1</id><subitem>2</subitem></item>");
         $this->assertNotNull($this->module->xmlRequest);
-        $dom = new \DOMDocument();
+        $dom = $this->createSecureDomDocument();
         $dom->load($this->layout);
         $body = $dom->createElement('item');
         $body->appendChild($dom->createElement('id',1));
@@ -60,7 +70,7 @@ class SoapTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testBuildRequestWithDomNode() {
-        $dom = new \DOMDocument();
+        $dom = $this->createSecureDomDocument();
         $dom->load($this->layout);
         $body = $dom->createElement('item');
         $body->appendChild($dom->createElement('id',1));


### PR DESCRIPTION
This pull request updates test data and unit tests to cover recent security vulnerabilities (400 series).

## Changes

- Updated test data and controller logic.
- Revised claypit test data for better coverage or security scenarios.
- Enhanced SoapTest unit tests, focusing on vulnerability coverage and regression checks.

## Testing

### 1. Automated Test Execution
- Run the full suite of Codeception tests:
  ```bash
  vendor/bin/codecept run
  ```
  Ensure all tests pass with zero failures or errors.

### 2. Unit Test Focus
- Pay special attention to changes in SoapTest:
  - Validate that new and updated test cases cover possible vulnerability scenarios.
  - Review test assertions to confirm they address targeted security issues.

### 3. Regression Checks
- Confirm that updates to test data do not break existing tests.
- Review modules that depend on these data files and run corresponding tests if available.

### 4. Security Validation
- Specifically test for vulnerabilities referenced in BAU-28341.
  - Attempt scenarios that previously exposed security issues and confirm they are now handled safely.
  - Ensure input validation, error handling, and data sanitization are covered in relevant tests.

### 5. Manual Testing (if applicable)
- If changes affect application behavior, manually verify endpoints or features related to modified logic.
- Simulate edge cases or invalid inputs to verify robustness.

### 6. Documentation & Reporting
- Document any issues encountered or unexpected behavior.
- Note any manual steps required for setup or execution of tests.
